### PR TITLE
Fix crash when reading custom log messages

### DIFF
--- a/classes/Model/Logreport.php
+++ b/classes/Model/Logreport.php
@@ -35,7 +35,7 @@ class Model_Logreport{
 
     protected function _createLogEntries()
     {
-        $pattern = "/(.*) --- ([A-Z]*): ([^:]*):? ([^~]*)~? (.*)/";
+    	$pattern = "/(.*?) --- ([A-Z]*): (?:(?:([^:]*): ([^~]*)~ (.*))|(.*))/";
         $last_log = null;
 		$message = '';
 		$start_trace = false;
@@ -52,9 +52,15 @@ class Model_Logreport{
 					$log['time'] = strtotime($matches[1]);
 					$log['level'] = $matches[2];    // Notice, Error etc.
 					$log['style'] = $this->_getStyle($matches[2]);    // CSS class for styling
-					$log['type'] = $matches[3];     // Exception name
-					$log['message'] = $matches[4];
-					$log['file'] = $matches[5];
+					if (isset($matches[6])) {
+						$log['type'] = $log['file'] = '';
+						$log['message'] = isset($matches[6]) ? $matches[6] : '';
+					}
+					else {
+						$log['type'] = $matches[3];     // Exception name
+						$log['message'] = $matches[4];
+						$log['file'] = $matches[5];
+					}
 				}
 
 				$this->_logEntries[] = $log;


### PR DESCRIPTION
My application is writing custom log messages to the log, these don't have the same format as the Exception-logs.
Because of that, the log-reader would crash because the regex did not return any matches

I changed the regex a bit, so that it supports log messages like:

```
2014-11-15 15:00:33 --- INFO: the actual message
```

The type and file are empty for these kind of messages.
